### PR TITLE
1. File Filter glob setting + relative Index Folder paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
+		"@types/micromatch": "^4.0.10",
 		"@types/node": "^20.11.24",
 		"@typescript-eslint/eslint-plugin": "^7.0.0",
 		"@typescript-eslint/parser": "^7.0.0",
@@ -26,6 +27,7 @@
 	},
 	"dependencies": {
 		"@google/generative-ai": "^0.23.0",
+		"micromatch": "^4.0.8",
 		"tesseract.js": "^5.0.4"
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,10 +52,10 @@ export default class ObsidianIndexer extends Plugin {
 		);
 
 		// Create converters
-		const pdfConverter = new PdfConverterService(fileDao, settingsService.indexFolder, pdfParser);
-		const pngConverter = new PngConverterService(fileDao, settingsService.indexFolder, pngParser);
-		const jpgConverter = new JpgConverterService(fileDao, settingsService.indexFolder, jpgParser);
-		const jpegConverter = new JpegConverterService(fileDao, settingsService.indexFolder, jpegParser);
+		const pdfConverter = new PdfConverterService(fileDao, settingsService.indexFolder, pdfParser, settingsService.fileFilter);
+		const pngConverter = new PngConverterService(fileDao, settingsService.indexFolder, pngParser, settingsService.fileFilter);
+		const jpgConverter = new JpgConverterService(fileDao, settingsService.indexFolder, jpgParser, settingsService.fileFilter);
+		const jpegConverter = new JpegConverterService(fileDao, settingsService.indexFolder, jpegParser, settingsService.fileFilter);
 
 		// Initialize converters and other services
 		const runConversion = async () => {

--- a/src/service/BaseConverterService.ts
+++ b/src/service/BaseConverterService.ts
@@ -33,10 +33,7 @@ export abstract class BaseConverterService {
                 f.path.endsWith(this.config.sourceExtension) &&
                 (!filteredPaths || filteredPaths.has(f.path))
             );
-            const convertedFiles = allFiles.filter(f =>
-                f.path.startsWith(`${this.config.indexFolder}/`) &&
-                f.path.endsWith(this.config.targetExtension)
-            );
+            const convertedFiles = this.findConvertedFileCandidates(allFiles, sourceFiles);
 
             const [removedFiles, createdFiles, modifiedFiles] = await Promise.all([
                 this.removeOrphanedFiles(convertedFiles, sourceFiles),
@@ -91,6 +88,38 @@ export abstract class BaseConverterService {
         }
         if (remaining) parts.push(remaining);
         return parts.join('/');
+    }
+
+    private findConvertedFileCandidates(allFiles: File[], sourceFiles: File[]): File[] {
+        if (!this.isRelativeIndexFolder()) {
+            const normalized = this.config.indexFolder.replace(/^\/+/, '').replace(/\/+$/, '');
+            return allFiles.filter(f =>
+                f.path.startsWith(`${normalized}/`) &&
+                f.path.endsWith(this.config.targetExtension)
+            );
+        }
+
+        // Relative indexFolder: derive output dirs from current source files.
+        // When no sources remain (all deleted), fall back to scanning all files
+        // with the target extension — the content-marker check in deleteFile
+        // acts as the safety net against deleting user-created files.
+        const outputDirs = new Set(
+            sourceFiles.map(source => {
+                const outputPath = this.getConvertedFilePath(source.path);
+                return outputPath.includes('/')
+                    ? outputPath.split('/').slice(0, -1).join('/')
+                    : '';
+            })
+        );
+
+        return allFiles.filter(f => {
+            if (!f.path.endsWith(this.config.targetExtension)) return false;
+            if (sourceFiles.length === 0) return true;
+            const dir = f.path.includes('/')
+                ? f.path.split('/').slice(0, -1).join('/')
+                : '';
+            return outputDirs.has(dir);
+        });
     }
 
     protected async removeOrphanedFiles(convertedFiles: File[], sourceFiles: File[]): Promise<string[]> {

--- a/src/service/BaseConverterService.ts
+++ b/src/service/BaseConverterService.ts
@@ -1,3 +1,4 @@
+import micromatch from 'micromatch';
 import { File, FileDao } from "../dao/FileDao";
 import { FatalProcessingError } from './AttachmentParserService';
 
@@ -5,6 +6,7 @@ export interface ConversionConfig {
     indexFolder: string;
     sourceExtension: string;
     targetExtension: string;
+    fileFilter?: string;
 }
 
 export abstract class BaseConverterService {
@@ -13,12 +15,24 @@ export abstract class BaseConverterService {
         protected config: ConversionConfig
     ) {}
 
+    private isRelativeIndexFolder(): boolean {
+        return this.config.indexFolder.startsWith('./') || this.config.indexFolder.startsWith('../');
+    }
+
     async convertFiles(): Promise<void> {
         try {
-            await this.fileDao.createFolder(this.config.indexFolder);
+            if (!this.isRelativeIndexFolder()) {
+                await this.fileDao.createFolder(this.config.indexFolder);
+            }
 
             const allFiles = await this.fileDao.getFiles();
-            const sourceFiles = allFiles.filter(f => f.path.endsWith(this.config.sourceExtension));
+            const filteredPaths = this.config.fileFilter
+                ? new Set(micromatch(allFiles.map(f => f.path), this.config.fileFilter))
+                : null;
+            const sourceFiles = allFiles.filter(f =>
+                f.path.endsWith(this.config.sourceExtension) &&
+                (!filteredPaths || filteredPaths.has(f.path))
+            );
             const convertedFiles = allFiles.filter(f =>
                 f.path.startsWith(`${this.config.indexFolder}/`) &&
                 f.path.endsWith(this.config.targetExtension)
@@ -46,8 +60,37 @@ export abstract class BaseConverterService {
         return file.name.slice(0, -this.config.targetExtension.length) + this.config.sourceExtension;
     }
 
-    protected getConvertedFilePath(sourceName: string): string {
-        return `${this.config.indexFolder}/${sourceName.slice(0, -this.config.sourceExtension.length)}${this.config.targetExtension}`;
+    protected getConvertedFilePath(sourcePath: string): string {
+        const sourceName = sourcePath.split('/').pop()!;
+        const sourceDir = sourcePath.includes('/')
+            ? sourcePath.split('/').slice(0, -1).join('/')
+            : '';
+        const outputFilename = sourceName.slice(0, -this.config.sourceExtension.length) + this.config.targetExtension;
+        const indexFolder = this.config.indexFolder;
+
+        if (this.isRelativeIndexFolder()) {
+            const resolvedDir = this.resolveRelativeDir(sourceDir, indexFolder);
+            return resolvedDir ? `${resolvedDir}/${outputFilename}` : outputFilename;
+        }
+
+        // Vault-root-relative: normalize leading/trailing slashes
+        const normalized = indexFolder.replace(/^\/+/, '').replace(/\/+$/, '');
+        return normalized ? `${normalized}/${outputFilename}` : outputFilename;
+    }
+
+    private resolveRelativeDir(sourceDir: string, indexFolder: string): string {
+        const parts = sourceDir ? sourceDir.split('/') : [];
+        let remaining = indexFolder;
+
+        while (remaining.startsWith('../')) {
+            if (parts.length > 0) parts.pop();
+            remaining = remaining.slice(3);
+        }
+        if (remaining.startsWith('./')) {
+            remaining = remaining.slice(2);
+        }
+        if (remaining) parts.push(remaining);
+        return parts.join('/');
     }
 
     protected async removeOrphanedFiles(convertedFiles: File[], sourceFiles: File[]): Promise<string[]> {
@@ -77,7 +120,7 @@ export abstract class BaseConverterService {
         const processedNames = [];
         for (const source of sourceFiles.filter(source => !convertedNames.has(source.name))) {
             try {
-                const targetPath = this.getConvertedFilePath(source.name);
+                const targetPath = this.getConvertedFilePath(source.path);
                 await this.convertAndSave(source, targetPath);
                 processedNames.push(source.name);
             } catch (error) {
@@ -106,7 +149,7 @@ export abstract class BaseConverterService {
             const convertedFile = convertedFileMap.get(source.name);
             if (convertedFile && source.modifiedTime >= convertedFile.modifiedTime) {
                 try {
-                    const targetPath = this.getConvertedFilePath(source.name);
+                    const targetPath = this.getConvertedFilePath(source.path);
                     await this.convertAndSave(source, targetPath);
                     modifiedFileNames.push(source.name);
                 } catch (error) {

--- a/src/service/CanvasService.ts
+++ b/src/service/CanvasService.ts
@@ -8,7 +8,8 @@ export class CanvasService extends BaseConverterService {
 		super(fileDao, {
 			indexFolder: config.indexFolder,
 			sourceExtension: '.canvas',
-			targetExtension: config.canvasPostfix
+			targetExtension: config.canvasPostfix,
+			fileFilter: config.fileFilter
 		});
 	}
 

--- a/src/service/CanvasServiceConfig.ts
+++ b/src/service/CanvasServiceConfig.ts
@@ -2,4 +2,5 @@ export interface CanvasServiceConfig {
 	readonly indexFolder: string;
 	readonly canvasPostfix: string;
 	readonly runOnStart: boolean;
+	readonly fileFilter?: string;
 }

--- a/src/service/JpegConverterService.ts
+++ b/src/service/JpegConverterService.ts
@@ -5,14 +5,16 @@ import { AttachmentParserService } from './AttachmentParserService';
 
 export class JpegConverterService extends BaseConverterService {
     constructor(
-        fileDao: FileDao, 
+        fileDao: FileDao,
         indexFolder: string,
-        private parser: AttachmentParserService
+        private parser: AttachmentParserService,
+        fileFilter?: string
     ) {
         super(fileDao, {
             indexFolder,
             sourceExtension: '.jpeg',
-            targetExtension: '.jpeg.md'
+            targetExtension: '.jpeg.md',
+            fileFilter
         });
     }
 

--- a/src/service/JpgConverterService.ts
+++ b/src/service/JpgConverterService.ts
@@ -5,14 +5,16 @@ import { AttachmentParserService } from './AttachmentParserService';
 
 export class JpgConverterService extends BaseConverterService {
     constructor(
-        fileDao: FileDao, 
+        fileDao: FileDao,
         indexFolder: string,
-        private parser: AttachmentParserService
+        private parser: AttachmentParserService,
+        fileFilter?: string
     ) {
         super(fileDao, {
             indexFolder,
             sourceExtension: '.jpg',
-            targetExtension: '.jpg.md'
+            targetExtension: '.jpg.md',
+            fileFilter
         });
     }
 

--- a/src/service/PdfConverterService.ts
+++ b/src/service/PdfConverterService.ts
@@ -5,14 +5,16 @@ import { AttachmentParserService } from './AttachmentParserService';
 
 export class PdfConverterService extends BaseConverterService {
     constructor(
-        fileDao: FileDao, 
+        fileDao: FileDao,
         indexFolder: string,
-        private parser: AttachmentParserService
+        private parser: AttachmentParserService,
+        fileFilter?: string
     ) {
         super(fileDao, {
             indexFolder,
             sourceExtension: '.pdf',
-            targetExtension: '.pdf.md'
+            targetExtension: '.pdf.md',
+            fileFilter
         });
     }
 

--- a/src/service/PngConverterService.ts
+++ b/src/service/PngConverterService.ts
@@ -5,14 +5,16 @@ import { AttachmentParserService } from './AttachmentParserService';
 
 export class PngConverterService extends BaseConverterService {
     constructor(
-        fileDao: FileDao, 
+        fileDao: FileDao,
         indexFolder: string,
-        private parser: AttachmentParserService
+        private parser: AttachmentParserService,
+        fileFilter?: string
     ) {
         super(fileDao, {
             indexFolder,
             sourceExtension: '.png',
-            targetExtension: '.png.md'
+            targetExtension: '.png.md',
+            fileFilter
         });
     }
 

--- a/src/service/SettingsService.ts
+++ b/src/service/SettingsService.ts
@@ -2,11 +2,14 @@ import {Plugin} from 'obsidian';
 import {CanvasServiceConfig} from "../service/CanvasServiceConfig";
 import { AttachmentParserConfig } from './AttachmentParserService';
 
+export const DEFAULT_FILE_FILTER = '**/*.{canvas,pdf,png,jpg,jpeg}';
+
 export interface Settings {
 	runOnStart: boolean;
 	runOnStartMobile: boolean;
 	indexFolder: string;
 	googleApiKey: string;
+	fileFilter: string;
 }
 
 export interface SettingsService extends CanvasServiceConfig {
@@ -15,12 +18,14 @@ export interface SettingsService extends CanvasServiceConfig {
 	readonly indexFolder: string;
 	readonly googleApiKey: string;
 	readonly canvasPostfix: string;
+	readonly fileFilter: string;
 	getApiKey(): string;
 
 	updateRunOnStart(value: boolean): Promise<void>;
 	updateRunOnStartMobile(value: boolean): Promise<void>;
 	updateIndexFolder(value: string): Promise<void>;
 	updateGoogleApiKey(value: string): Promise<void>;
+	updateFileFilter(value: string): Promise<void>;
 	restoreDefaults(): Promise<void>;
 }
 
@@ -53,6 +58,10 @@ export class SettingsServiceImpl implements SettingsService, AttachmentParserCon
 		return this.settings.googleApiKey;
 	}
 
+	get fileFilter(): string {
+		return this.settings.fileFilter;
+	}
+
 	getApiKey(): string {
 		return this.settings.googleApiKey;
 	}
@@ -75,12 +84,17 @@ export class SettingsServiceImpl implements SettingsService, AttachmentParserCon
 	}
 
 	async updateIndexFolder(value: string): Promise<void> {
-		this.settings.indexFolder = value;
+		this.settings.indexFolder = value.length < 2 ? 'index' : value;
 		await this.saveSettings();
 	}
 
 	async updateGoogleApiKey(value: string): Promise<void> {
 		this.settings.googleApiKey = value;
+		await this.saveSettings();
+	}
+
+	async updateFileFilter(value: string): Promise<void> {
+		this.settings.fileFilter = value;
 		await this.saveSettings();
 	}
 
@@ -94,7 +108,8 @@ export class SettingsServiceImpl implements SettingsService, AttachmentParserCon
 			runOnStart: true,
 			runOnStartMobile: false, // Default to false for mobile for safety
 			indexFolder: 'index',
-			googleApiKey: ''
+			googleApiKey: '',
+			fileFilter: DEFAULT_FILE_FILTER
 		};
 	}
 

--- a/src/utils/SettingsTab.ts
+++ b/src/utils/SettingsTab.ts
@@ -26,7 +26,9 @@ export class SettingsTab extends PluginSettingTab {
 			<li><strong>PDF files</strong> (.pdf): Creates markdown files with PDF viewer and extracts complete text content for searching (requires Google API key)</li>
 			<li><strong>Image files</strong> (.png, .jpg, .jpeg): Creates markdown files with embedded images and extracts all visible text for searching (requires Google API key)</li>
 		</ul>
-		All indexed files are stored in the specified index folder with their original extension plus ".md" (e.g., file.canvas → index/file.canvas.md). The plugin maintains synchronization, updating index files when originals change and removing them when originals are deleted.`;
+		All indexed files are stored in the specified index folder with their original extension plus ".md" (e.g., file.canvas → index/file.canvas.md). The plugin maintains synchronization, updating index files when originals change and removing them when originals are deleted.
+		<br><br>
+		<strong>Orphan cleanup with relative paths:</strong> When using a relative Index Folder (e.g. <code>../</code>), each source file's output lands in a different folder. The plugin scans all derived output folders rather than a single central folder, and uses content markers to identify generated files — so it will never delete user-created files that happen to share a name pattern.`;
 
 		new Setting(containerEl)
 			.setName('Run on start')
@@ -47,15 +49,32 @@ export class SettingsTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
+			.setName('File Filter')
+			.setDesc('Only process files that match this glob pattern')
+			.addText(text => text
+				.setPlaceholder('**/*.{canvas,pdf,png,jpg,jpeg}')
+				.setValue(this.settingsService.fileFilter)
+				.onChange(async (value) => {
+					await this.settingsService.updateFileFilter(value);
+				}));
+
+		new Setting(containerEl)
 			.setName('Index folder')
-			.setDesc('Folder to store converted files (must be at least 3 chars). If you change this, you need to manually rename or delete the old folder and re-run the conversion.')
+			.setDesc(createFragment(el => {
+				el.appendText('Folder to store converted files. Supports relative paths: ');
+				el.createEl('code', {text: './'});
+				el.appendText(' places index files alongside the originals, ');
+				el.createEl('code', {text: '../'});
+				el.appendText(' places them in the parent folder. Example: set Filter to ');
+				el.createEl('code', {text: '**/attachments/*.pdf'});
+				el.appendText(' and Index Folder to ');
+				el.createEl('code', {text: '../'});
+				el.appendText(' to index all PDFs in any attachments/ folder and place the .pdf.md output in its parent. If you change this setting, manually rename or delete the old folder and re-run the conversion.');
+			}))
 			.addText(text => text
 				.setPlaceholder('index')
 				.setValue(this.settingsService.indexFolder)
 				.onChange(async (value) => {
-					if (value.length < 3) {
-						value = 'index';
-					}
 					await this.settingsService.updateIndexFolder(value);
 				}));
 

--- a/test/SettingsService.test.ts
+++ b/test/SettingsService.test.ts
@@ -1,0 +1,55 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+import {SettingsServiceImpl} from '../src/service/SettingsService';
+import {Plugin} from 'obsidian';
+
+function makePlugin(): Plugin {
+	const plugin = new Plugin() as Plugin & {loadData: () => Promise<unknown>; saveData: (data: unknown) => Promise<void>};
+	plugin.loadData = async () => ({});
+	plugin.saveData = async () => {};
+	return plugin;
+}
+
+describe('SettingsService', () => {
+	let service: SettingsServiceImpl;
+
+	beforeEach(() => {
+		service = new SettingsServiceImpl(makePlugin());
+	});
+
+	it('fileFilter defaults to **/*.{canvas,pdf,png,jpg,jpeg}', () => {
+		expect(service.fileFilter).toBe('**/*.{canvas,pdf,png,jpg,jpeg}');
+	});
+
+	it('updateFileFilter persists the new value', async () => {
+		await service.updateFileFilter('custom/**/*.png');
+		expect(service.fileFilter).toBe('custom/**/*.png');
+	});
+
+	it('restoreDefaults resets fileFilter to default', async () => {
+		await service.updateFileFilter('custom/**/*.png');
+		await service.restoreDefaults();
+		expect(service.fileFilter).toBe('**/*.{canvas,pdf,png,jpg,jpeg}');
+	});
+
+	describe('updateIndexFolder', () => {
+		it('accepts a 2-character value like "./"', async () => {
+			await service.updateIndexFolder('./');
+			expect(service.indexFolder).toBe('./');
+		});
+
+		it('accepts a 3-character value like "../"', async () => {
+			await service.updateIndexFolder('../');
+			expect(service.indexFolder).toBe('../');
+		});
+
+		it('falls back to "index" for a 1-character value', async () => {
+			await service.updateIndexFolder('x');
+			expect(service.indexFolder).toBe('index');
+		});
+
+		it('falls back to "index" for an empty string', async () => {
+			await service.updateIndexFolder('');
+			expect(service.indexFolder).toBe('index');
+		});
+	});
+});

--- a/test/integration/GlobFilterConversion.test.ts
+++ b/test/integration/GlobFilterConversion.test.ts
@@ -1,0 +1,88 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+import {CanvasService} from '../../src/service/CanvasService';
+import {FileDaoImpl} from '../../src/dao/FileDaoImpl';
+import {InMemoryFileAdapter} from '../dao/InMemoryFileAdapter';
+import {readTestFile} from '../utils/testFileUtils';
+
+const CANVAS_CONTENT = readTestFile('Test.canvas');
+
+describe('Integration Test: Glob Filter', () => {
+	let fileAdapter: InMemoryFileAdapter;
+	let fileDao: FileDaoImpl;
+
+	beforeEach(() => {
+		fileAdapter = new InMemoryFileAdapter();
+		fileDao = new FileDaoImpl(fileAdapter);
+	});
+
+	it('filter attachments/*.canvas — * is single-level: processes file in attachments/ at vault root, ignores nested and root', async () => {
+		await fileDao.createOrUpdateFile('attachments/InFilter.canvas', CANVAS_CONTENT);
+		await fileDao.createOrUpdateFile('NotInFilter.canvas', CANVAS_CONTENT);
+		await fileDao.createOrUpdateFile('deep/attachments/AlsoNotInFilter.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: 'index',
+			fileFilter: 'attachments/*.canvas',
+		});
+		await service.convertFiles();
+
+		expect(await fileAdapter.read('index/InFilter.canvas.md')).toBeDefined();
+		await expect(fileAdapter.read('index/NotInFilter.canvas.md')).rejects.toThrow();
+		await expect(fileAdapter.read('index/AlsoNotInFilter.canvas.md')).rejects.toThrow();
+	});
+
+	it('filter with brace expansion *.{canvas,md} — matches multiple extensions', async () => {
+		await fileDao.createOrUpdateFile('attachments/Doc.canvas', CANVAS_CONTENT);
+		await fileDao.createOrUpdateFile('attachments/Note.md', '# note');
+		await fileDao.createOrUpdateFile('attachments/Image.png', 'binary');
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: 'index',
+			fileFilter: 'attachments/*.{canvas,md}',
+		});
+		await service.convertFiles();
+
+		// canvas matches filter AND is the converter's source extension → processed
+		expect(await fileAdapter.read('index/Doc.canvas.md')).toBeDefined();
+		// .png does not match filter → not processed (CanvasService wouldn't handle it anyway, but it's excluded at the gate)
+	});
+
+	it('no fileFilter set — all canvas files anywhere in vault are processed (no regression)', async () => {
+		await fileDao.createOrUpdateFile('root.canvas', CANVAS_CONTENT);
+		await fileDao.createOrUpdateFile('deep/nested/file.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: 'index',
+		});
+		await service.convertFiles();
+
+		expect(await fileAdapter.read('index/root.canvas.md')).toBeDefined();
+		expect(await fileAdapter.read('index/file.canvas.md')).toBeDefined();
+	});
+
+	it('filter **/attachments/*.canvas — ** is recursive: processes files in any attachments/ folder at any depth', async () => {
+		await fileDao.createOrUpdateFile('attachments/Root.canvas', CANVAS_CONTENT);
+		await fileDao.createOrUpdateFile('deep/attachments/Nested.canvas', CANVAS_CONTENT);
+		await fileDao.createOrUpdateFile('a/b/c/attachments/VeryNested.canvas', CANVAS_CONTENT);
+		await fileDao.createOrUpdateFile('NotInFilter.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: 'index',
+			fileFilter: '**/attachments/*.canvas',
+		});
+		await service.convertFiles();
+
+		expect(await fileAdapter.read('index/Root.canvas.md')).toBeDefined();
+		expect(await fileAdapter.read('index/Nested.canvas.md')).toBeDefined();
+		expect(await fileAdapter.read('index/VeryNested.canvas.md')).toBeDefined();
+		await expect(fileAdapter.read('index/NotInFilter.canvas.md')).rejects.toThrow();
+	});
+});

--- a/test/integration/GlobFilterConversion.test.ts
+++ b/test/integration/GlobFilterConversion.test.ts
@@ -3,6 +3,7 @@ import {CanvasService} from '../../src/service/CanvasService';
 import {FileDaoImpl} from '../../src/dao/FileDaoImpl';
 import {InMemoryFileAdapter} from '../dao/InMemoryFileAdapter';
 import {readTestFile} from '../utils/testFileUtils';
+import {DEFAULT_FILE_FILTER} from '../../src/service/SettingsService';
 
 const CANVAS_CONTENT = readTestFile('Test.canvas');
 
@@ -49,6 +50,28 @@ describe('Integration Test: Glob Filter', () => {
 		// canvas matches filter AND is the converter's source extension → processed
 		expect(await fileAdapter.read('index/Doc.canvas.md')).toBeDefined();
 		// .png does not match filter → not processed (CanvasService wouldn't handle it anyway, but it's excluded at the gate)
+	});
+
+	it('DEFAULT_FILE_FILTER matches canvas files at any depth in the vault', async () => {
+		await fileDao.createOrUpdateFile('root.canvas', CANVAS_CONTENT);
+		await fileDao.createOrUpdateFile('deep/nested/file.canvas', CANVAS_CONTENT);
+		await fileDao.createOrUpdateFile('attachments/doc.canvas', CANVAS_CONTENT);
+		// Non-matching extension — should not be processed by CanvasService
+		await fileDao.createOrUpdateFile('deep/image.png', 'binary');
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: 'index',
+			fileFilter: DEFAULT_FILE_FILTER,
+		});
+		await service.convertFiles();
+
+		expect(await fileAdapter.read('index/root.canvas.md')).toBeDefined();
+		expect(await fileAdapter.read('index/file.canvas.md')).toBeDefined();
+		expect(await fileAdapter.read('index/doc.canvas.md')).toBeDefined();
+		// .png passes the filter but CanvasService ignores it — no .png.md created
+		await expect(fileAdapter.read('index/image.canvas.md')).rejects.toThrow();
 	});
 
 	it('no fileFilter set — all canvas files anywhere in vault are processed (no regression)', async () => {

--- a/test/integration/OrphanDetection.test.ts
+++ b/test/integration/OrphanDetection.test.ts
@@ -1,0 +1,115 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+import {CanvasService} from '../../src/service/CanvasService';
+import {FileDaoImpl} from '../../src/dao/FileDaoImpl';
+import {InMemoryFileAdapter} from '../dao/InMemoryFileAdapter';
+import {readTestFile} from '../utils/testFileUtils';
+
+const CANVAS_CONTENT = readTestFile('Test.canvas');
+
+describe('Integration Test: Orphan Detection', () => {
+	let fileAdapter: InMemoryFileAdapter;
+	let fileDao: FileDaoImpl;
+
+	beforeEach(() => {
+		fileAdapter = new InMemoryFileAdapter();
+		fileDao = new FileDaoImpl(fileAdapter);
+	});
+
+	it('vault-root-relative — orphan in index/ is cleaned up (no regression)', async () => {
+		await fileDao.createOrUpdateFile('Test.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: 'index',
+		});
+
+		await service.convertFiles();
+		expect(await fileAdapter.read('index/Test.canvas.md')).toBeDefined();
+
+		await fileAdapter.delete('Test.canvas');
+		await service.convertFiles();
+
+		await expect(fileAdapter.read('index/Test.canvas.md')).rejects.toThrow();
+	});
+
+	it('../ — deleting the source removes the orphaned index file at vault root', async () => {
+		await fileDao.createOrUpdateFile('attachments/Test.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: '../',
+		});
+
+		await service.convertFiles();
+		expect(await fileAdapter.read('Test.canvas.md')).toBeDefined();
+
+		await fileAdapter.delete('attachments/Test.canvas');
+		await service.convertFiles();
+
+		await expect(fileAdapter.read('Test.canvas.md')).rejects.toThrow();
+	});
+
+	it('../ — two sources, one deleted → orphan removed, sibling index kept', async () => {
+		await fileDao.createOrUpdateFile('attachments/A.canvas', CANVAS_CONTENT);
+		await fileDao.createOrUpdateFile('attachments/B.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: '../',
+		});
+
+		await service.convertFiles();
+		expect(await fileAdapter.read('A.canvas.md')).toBeDefined();
+		expect(await fileAdapter.read('B.canvas.md')).toBeDefined();
+
+		await fileAdapter.delete('attachments/B.canvas');
+		await service.convertFiles();
+
+		// B orphan removed, A kept
+		await expect(fileAdapter.read('B.canvas.md')).rejects.toThrow();
+		expect(await fileAdapter.read('A.canvas.md')).toBeDefined();
+	});
+
+	it('./index — deleting the source removes the orphan in the relative subfolder', async () => {
+		await fileDao.createOrUpdateFile('attachments/Test.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: './index',
+		});
+
+		await service.convertFiles();
+		expect(await fileAdapter.read('attachments/index/Test.canvas.md')).toBeDefined();
+
+		await fileAdapter.delete('attachments/Test.canvas');
+		await service.convertFiles();
+
+		await expect(fileAdapter.read('attachments/index/Test.canvas.md')).rejects.toThrow();
+	});
+
+	it('content-marker safety — user file with .canvas.md extension in output dir is not deleted', async () => {
+		await fileDao.createOrUpdateFile('attachments/Test.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: '../',
+		});
+
+		await service.convertFiles();
+
+		// User creates their own .canvas.md note at root (no content marker)
+		await fileDao.createOrUpdateFile('MyNote.canvas.md', '# My own note, no marker here');
+
+		await fileAdapter.delete('attachments/Test.canvas');
+		await service.convertFiles();
+
+		// Plugin-generated orphan deleted, user file untouched
+		await expect(fileAdapter.read('Test.canvas.md')).rejects.toThrow();
+		expect(await fileAdapter.read('MyNote.canvas.md')).toBe('# My own note, no marker here');
+	});
+});

--- a/test/integration/RelativeIndexFolder.test.ts
+++ b/test/integration/RelativeIndexFolder.test.ts
@@ -1,0 +1,111 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+import {CanvasService} from '../../src/service/CanvasService';
+import {FileDaoImpl} from '../../src/dao/FileDaoImpl';
+import {InMemoryFileAdapter} from '../dao/InMemoryFileAdapter';
+import {readTestFile} from '../utils/testFileUtils';
+
+const CANVAS_CONTENT = readTestFile('Test.canvas');
+
+describe('Integration Test: Relative Index Folder', () => {
+	let fileAdapter: InMemoryFileAdapter;
+	let fileDao: FileDaoImpl;
+
+	beforeEach(() => {
+		fileAdapter = new InMemoryFileAdapter();
+		fileDao = new FileDaoImpl(fileAdapter);
+	});
+
+	it('../ with source attachments/file.canvas → output at file.canvas.md (vault root)', async () => {
+		await fileDao.createOrUpdateFile('attachments/Test.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: '../',
+		});
+		await service.convertFiles();
+
+		expect(await fileAdapter.read('Test.canvas.md')).toBeDefined();
+	});
+
+	it('./index with source attachments/file.canvas → output at attachments/index/file.canvas.md', async () => {
+		await fileDao.createOrUpdateFile('attachments/Test.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: './index',
+		});
+		await service.convertFiles();
+
+		expect(await fileAdapter.read('attachments/index/Test.canvas.md')).toBeDefined();
+	});
+
+	it('../ with source a/b/attachments/file.canvas → output at a/b/file.canvas.md', async () => {
+		await fileDao.createOrUpdateFile('a/b/attachments/Test.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: '../',
+		});
+		await service.convertFiles();
+
+		expect(await fileAdapter.read('a/b/Test.canvas.md')).toBeDefined();
+	});
+
+	it('../ with source file.canvas at vault root → output at file.canvas.md (clamped, no error)', async () => {
+		await fileDao.createOrUpdateFile('Test.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: '../',
+		});
+		await service.convertFiles();
+
+		expect(await fileAdapter.read('Test.canvas.md')).toBeDefined();
+	});
+
+	it('vault-root-relative "index" → output at index/file.canvas.md (no regression)', async () => {
+		await fileDao.createOrUpdateFile('Test.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: 'index',
+		});
+		await service.convertFiles();
+
+		expect(await fileAdapter.read('index/Test.canvas.md')).toBeDefined();
+	});
+
+	it('slash normalization: "/index", "index", "index/" all produce index/file.canvas.md', async () => {
+		for (const indexFolder of ['/index', 'index', 'index/']) {
+			fileAdapter.clear();
+			await fileDao.createOrUpdateFile('Test.canvas', CANVAS_CONTENT);
+
+			const service = new CanvasService(fileDao, {
+				canvasPostfix: '.canvas.md',
+				runOnStart: false,
+				indexFolder,
+			});
+			await service.convertFiles();
+
+			expect(await fileAdapter.read('index/Test.canvas.md'), `indexFolder="${indexFolder}"`).toBeDefined();
+		}
+	});
+
+	it('./ places output alongside source file', async () => {
+		await fileDao.createOrUpdateFile('attachments/Test.canvas', CANVAS_CONTENT);
+
+		const service = new CanvasService(fileDao, {
+			canvasPostfix: '.canvas.md',
+			runOnStart: false,
+			indexFolder: './',
+		});
+		await service.convertFiles();
+
+		expect(await fileAdapter.read('attachments/Test.canvas.md')).toBeDefined();
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
 		"importHelpers": true,
 		"isolatedModules": true,
 		"strictNullChecks": true,
+		"esModuleInterop": true,
 		"lib": [
 			"DOM",
 			"ES5",
@@ -20,5 +21,8 @@
 	},
 	"include": [
 		"**/*.ts"
+	],
+	"exclude": [
+		"test/**/*.ts"
 	]
 }


### PR DESCRIPTION
closes #5

## Summary

  - **File Filter setting** — a glob pattern (default `**/*.{canvas,pdf,png,jpg,jpeg}`) that restricts which files are processed. Uses standard glob semantics: `*` = single directory level, `**` = recursive, `{a,b}` = brace expansion. Powered by
   `micromatch`.
  - **Relative Index Folder** — `./` and `../` prefixes resolve the output path relative to each source file's directory rather than the vault root. Vault-root-relative values (`index`, `/index`, `index/`) are unchanged. `../` at vault root
  clamps instead of erroring.
  - **Orphan cleanup** updated to work with relative paths: derives output directories from current source files; falls back to scanning all target-extension files when no sources remain (content-marker check in `deleteFile` acts as safety net).
  - **Index Folder minimum length** lowered from 3 to 2 characters (to allow `./`), validation moved to service layer.
  - **Settings UI** updated with File Filter input and improved Index Folder description with `./`/`../` examples.

  ### Motivating use case

  Set File Filter to `**/attachments/*.pdf` and Index Folder to `../` → the plugin processes only PDFs inside any `attachments/` folder and places each `.pdf.md` in the parent of that `attachments/` folder, wherever it lives in the vault.

  ## Test plan

  - [x] `GlobFilterConversion.test.ts` — `*` single-level, `**` recursive, brace expansion, `DEFAULT_FILE_FILTER` coverage, no-filter regression
  - [x] `RelativeIndexFolder.test.ts` — `./index`, `../`, multi-level nesting, vault-root clamping, slash normalization
  - [x] `OrphanDetection.test.ts` — vault-root-relative regression, `../` single source, `../` partial deletion, `./index`, content-marker safety
  - [x] `SettingsService.test.ts` — `fileFilter` default, update, restore; `indexFolder` min-length validation

  51 tests passing, 0 regressions.